### PR TITLE
rebuild blases for animated meshes

### DIFF
--- a/src/engine/core/math_utils.hpp
+++ b/src/engine/core/math_utils.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstdint>
+
+inline uint32_t round_up(const uint32_t num, const uint32_t multiple) {
+    if(multiple == 0) {
+        return num;
+    }
+
+    auto remainder = num % multiple;
+    if(remainder == 0) {
+        return num;
+    }
+
+    return num + multiple - remainder;
+}

--- a/src/engine/render/backend/blas_build_queue.cpp
+++ b/src/engine/render/backend/blas_build_queue.cpp
@@ -6,6 +6,7 @@
 #include "render_backend.hpp"
 #include "render/backend/render_graph.hpp"
 #include "console/cvars.hpp"
+#include "core/math_utils.hpp"
 
 namespace render {
     static auto cvar_max_concurrent_builds = AutoCVar_Int{
@@ -42,10 +43,12 @@ namespace render {
         auto& allocator = backend.get_global_allocator();
         const auto scratch_buffer = allocator.create_buffer(
             "Scratch buffer",
-            max_scratch_buffer_size * batch_size,
+            max_scratch_buffer_size * (batch_size + 1),
             BufferUsage::StorageBuffer);
 
         allocator.destroy_buffer(scratch_buffer);
+
+        const auto alignment = backend.get_rt_scratch_buffer_alignment();
 
         for (auto i = 0u; i < pending_jobs.size(); i += batch_size) {
             auto barriers = BufferUsageList{
@@ -65,7 +68,7 @@ namespace render {
             build_range_infos.reserve(batch_size);
             build_range_info_ptrs.reserve(batch_size);
 
-            auto scratch_buffer_address = scratch_buffer->address;
+            auto scratch_buffer_address = round_up(scratch_buffer->address, alignment);
 
             for (auto job_idx = i; job_idx < i + batch_size; job_idx++) {
                 if (job_idx >= pending_jobs.size()) {
@@ -83,6 +86,7 @@ namespace render {
 
                 auto& info = job.build_info;
                 info.dstAccelerationStructure = job.handle->acceleration_structure;
+                info.geometryCount = 1;
                 info.pGeometries = &job.create_info;
                 info.scratchData = {.deviceAddress = scratch_buffer_address};
                 build_geometry_infos.emplace_back(info);

--- a/src/engine/render/backend/pipeline_cache.cpp
+++ b/src/engine/render/backend/pipeline_cache.cpp
@@ -1,6 +1,8 @@
 #include <vulkan/vk_enum_string_helper.h>
 
 #include "render/backend/pipeline_cache.hpp"
+
+#include "core/math_utils.hpp"
 #include "render/backend/pipeline_builder.hpp"
 #include "render/backend/ray_tracing_pipeline.hpp"
 #include "render/backend/render_backend.hpp"
@@ -394,19 +396,6 @@ namespace render {
                 .gi_anyhit_shader = shader_group.gi_anyhit_shader,
                 .gi_closesthit_shader = shader_group.gi_closesthit_shader
             }));
-    }
-
-    static uint32_t round_up(const uint32_t num, const uint32_t multiple) {
-        if(multiple == 0) {
-            return num;
-        }
-
-        auto remainder = num % multiple;
-        if(remainder == 0) {
-            return num;
-        }
-
-        return num + multiple - remainder;
     }
 
     RayTracingPipelineHandle PipelineCache::create_ray_tracing_pipeline(const ResourcePath& raygen_shader_path,

--- a/src/engine/render/backend/render_backend.cpp
+++ b/src/engine/render/backend/render_backend.cpp
@@ -402,6 +402,7 @@ namespace render {
 
         if(supports_raytracing) {
             physical_device_properties.add_extension(&ray_tracing_pipeline_properties);
+            physical_device_properties.add_extension(&acceleration_structure_properties);
         }
 
         vkGetPhysicalDeviceProperties2(physical_device, *physical_device_properties);
@@ -499,6 +500,10 @@ namespace render {
 
     bool RenderBackend::supports_ray_tracing() const {
         return supports_rt; 
+    }
+
+    uint32_t RenderBackend::get_rt_scratch_buffer_alignment() const {
+        return acceleration_structure_properties.minAccelerationStructureScratchOffsetAlignment;
     }
 
     bool RenderBackend::supports_device_generated_commands() const {

--- a/src/engine/render/backend/render_backend.hpp
+++ b/src/engine/render/backend/render_backend.hpp
@@ -76,6 +76,8 @@ namespace render {
 
         bool supports_ray_tracing() const;
 
+        uint32_t get_rt_scratch_buffer_alignment() const;
+
         bool supports_device_generated_commands() const;
 
         const eastl::vector<glm::uvec2>& get_shading_rates() const;
@@ -320,6 +322,9 @@ namespace render {
 
         VkPhysicalDeviceRayTracingPipelinePropertiesKHR  ray_tracing_pipeline_properties = {
             .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR
+        };
+        VkPhysicalDeviceAccelerationStructurePropertiesKHR acceleration_structure_properties = {
+            .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_PROPERTIES_KHR
         };
         VkPhysicalDeviceFragmentShadingRatePropertiesKHR shading_rate_properties = {
             .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_PROPERTIES_KHR

--- a/src/engine/render/proxies/mesh_primitive_proxy.hpp
+++ b/src/engine/render/proxies/mesh_primitive_proxy.hpp
@@ -17,6 +17,8 @@ namespace render {
 
         bool visible_to_ray_tracing = true;
 
+        AccelerationStructureHandle blas = {};
+
         size_t placed_blas_index = eastl::numeric_limits<size_t>::max();
 
         void calculate_worldspace_bounds();

--- a/src/engine/render/raytracing_scene.hpp
+++ b/src/engine/render/raytracing_scene.hpp
@@ -29,6 +29,16 @@ namespace render {
 
         void set_dirty();
 
+        static AccelerationStructureHandle create_blas(
+            VkDeviceAddress vertices, uint32_t num_vertices, VkDeviceAddress indices, uint num_triangles,
+            bool is_dynamic
+            );
+
+        static AccelerationStructureHandle update_blas(
+            VkDeviceAddress vertices, uint32_t num_vertices, VkDeviceAddress indices, uint num_triangles,
+            AccelerationStructureHandle as
+            );
+
     private:
         RenderWorld& world;
 


### PR DESCRIPTION
this pr adds functionality to rebuild blases for animated meshes when the meshes change. it works very well with my test model. it has not been thoroughly tested